### PR TITLE
Fix typo: mx-autp → mx-auto

### DIFF
--- a/components/Navbars/AdminNavbar.js
+++ b/components/Navbars/AdminNavbar.js
@@ -7,7 +7,7 @@ export default function Navbar() {
     <>
       {/* Navbar */}
       <nav className="absolute top-0 left-0 w-full z-10 bg-transparent md:flex-row md:flex-nowrap md:justify-start flex items-center p-4">
-        <div className="w-full mx-autp items-center flex justify-between md:flex-nowrap flex-wrap md:px-10 px-4">
+        <div className="w-full mx-auto items-center flex justify-between md:flex-nowrap flex-wrap md:px-10 px-4">
           {/* Brand */}
           <a
             className="text-white text-sm uppercase hidden lg:inline-block font-semibold"


### PR DESCRIPTION
Fixes a typo in the `className` under AdminNavbar.js where `mx-autp` was used instead of `mx-auto`.